### PR TITLE
feat: Implement Inventory service API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '4'
 services:
   mysql:
     image: mysql:8.3.0
-    container_name: mysql
+    container_name: inventory-service-mysql
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,18 @@
 			<artifactId>mysql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<version>5.5.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/michael/inventory_service/controller/InventoryController.java
+++ b/src/main/java/com/michael/inventory_service/controller/InventoryController.java
@@ -1,0 +1,23 @@
+package com.michael.inventory_service.controller;
+
+import com.michael.inventory_service.service.InventoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/inventory")
+@RequiredArgsConstructor
+public class InventoryController {
+
+    private final InventoryService inventoryService;
+
+    @GetMapping
+    public ResponseEntity<Boolean> isInStock(@RequestParam String skuCode, @RequestParam Integer quantity){
+        return new ResponseEntity<>(inventoryService.isInStock(skuCode,quantity), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/michael/inventory_service/model/Inventory.java
+++ b/src/main/java/com/michael/inventory_service/model/Inventory.java
@@ -1,0 +1,23 @@
+package com.michael.inventory_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "t_inventory")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Inventory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String skuCode;
+    private Integer quantity;
+
+}

--- a/src/main/java/com/michael/inventory_service/repository/InventoryRepository.java
+++ b/src/main/java/com/michael/inventory_service/repository/InventoryRepository.java
@@ -1,0 +1,10 @@
+package com.michael.inventory_service.repository;
+
+import com.michael.inventory_service.model.Inventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InventoryRepository extends JpaRepository<Inventory, Long> {
+    boolean existsBySkuCodeAndQuantityIsGreaterThanEqual(String skuCode, Integer quantity);
+}

--- a/src/main/java/com/michael/inventory_service/service/InventoryService.java
+++ b/src/main/java/com/michael/inventory_service/service/InventoryService.java
@@ -1,0 +1,16 @@
+package com.michael.inventory_service.service;
+
+import com.michael.inventory_service.repository.InventoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryService {
+
+    private final InventoryRepository inventoryRepository;
+
+    public boolean isInStock(String skuCode, Integer quantity){
+        return inventoryRepository.existsBySkuCodeAndQuantityIsGreaterThanEqual(skuCode, quantity);
+    }
+}

--- a/src/test/java/com/michael/inventory_service/InventoryServiceApplicationTests.java
+++ b/src/test/java/com/michael/inventory_service/InventoryServiceApplicationTests.java
@@ -1,15 +1,57 @@
 package com.michael.inventory_service;
 
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.MySQLContainer;
 
-@Import(TestcontainersConfiguration.class)
-@SpringBootTest
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class InventoryServiceApplicationTests {
 
+	@ServiceConnection
+	static MySQLContainer mySQLContainer = new MySQLContainer<>("mysql:8.3.0");
+	@LocalServerPort
+	private Integer port;
+
+	@BeforeEach
+	void setup(){
+		RestAssured.baseURI = "http://localhost";
+		RestAssured.port = port;
+	}
+
+	static {
+		mySQLContainer.start();
+	}
+
 	@Test
-	void contextLoads() {
+	void shouldReadInventory() {
+
+		var response = RestAssured.given()
+				.when()
+				.get("/api/inventory?skuCode=iphone_15&quantity=1")
+				.then()
+				.log().all()
+				.statusCode(200)
+				.extract().response().as(Boolean.class);
+		assertTrue(response);
+
+		var negativeResponse = RestAssured.given()
+				.when()
+				.get("/api/inventory?skuCode=iphone_15&quantity=1000")
+				.then()
+				.log().all()
+				.statusCode(200)
+				.extract().response().as(Boolean.class);
+		assertFalse(negativeResponse);
 	}
 
 }


### PR DESCRIPTION
This commit introduces the initial API for the inventory service, including a new endpoint for checking if a product is in stock based on the skuCode and quantity as params. It also sets up the foundational model and repository layers.

Key changes:
- Created the Inventory model to represent the Inventory entity.
- Implemented the InventoryRepository for data access.
- Created the /inventory endpoint to check for product stock.
- Used FlyWay for database migration.
- Implemented integration tests for new endpoint using Testcontainers and Rest Assured.